### PR TITLE
Allow reading / writing an entire reducer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ You can find more usage examples by reading the tests.
 * `createPasswordTransform(config)` - Creates a new transform instance
 
 * `config (Object)` - Configuration parameters
-    * `serviceName (String)` - A unique identifier to reference passwords in the keychain
-    * `passwordPaths (String|Array<String>|((state) => String|Array<String>)` - Lodash getter path(s) to the state properties that should be written to `keytar`, or a function that, given your state, returns getter paths. `keytar` only supports writing strings, so if a property is not a string it will be coerced.
-    * `clearPasswords (Boolean)` - Whether or not to clear the properties from `passwordPaths` before the state is persisted. Defaults to `true`.
-    * `serialize (Boolean)` - Whether or not to serialize password properties as JSON strings. Defaults to `false`.
-    * `logger ((message, ...args) => void)` - An optional logging method. Defaults to `noop`.
+    * `serviceName (String)` - The top-level identifier for your app to store items in the keychain.
+    * `accountName (String)` - (Optional) A sub-identifier for individual entries. If not provided, strings taken from `passwordPaths` will be used.
+    * `passwordPaths (String|Array<String>|((state) => String|Array<String>)` - (Optional) Lodash getter path(s) to passwords in your state, or a function that, given your state, returns path(s). Leave empty to write the entire reducer.
+    * `clearPasswords (Boolean)` - (Optional) Whether or not to clear the properties from `passwordPaths` before the state is persisted. Defaults to `true`.
+    * `serialize (Boolean)` - (Optional) Whether or not to serialize password properties as JSON strings. Defaults to `false`.
+    * `logger ((message, ...args) => void)` - (Optional) An optional logging method. Defaults to `noop`.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-stage-2": "^6.24.1",
     "deep-freeze": "0.0.1",
+    "jest-cli": "^20.0.4",
     "rimraf": "~2.5.4"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,9 @@ import { createTransform } from 'redux-persist';
  *
  * @export
  * @param {Object} config
- * @param {String} config.serviceName       A unique identifier for your app to reference passwords in the keychain.
- * @param {String} [config.accountName]     A sub-identifier for individual entries. If not provided, paths taken from
- *                                          passwordPaths will be used.
+ * @param {String} config.serviceName       The top-level identifier for your app to store items in the keychain.
+ * @param {String} [config.accountName]     A sub-identifier for individual entries. If not provided, strings taken
+ *                                          from `passwordPaths` will be used.
  * @param {String|Array<String>|Function} [config.passwordPaths]  Lodash getter path(s) to passwords in your state, or
  *                                                                a function that, given your state, returns path(s).
  *                                                                Leave empty to write the entire reducer.

--- a/type-definitions/index.d.ts
+++ b/type-definitions/index.d.ts
@@ -4,7 +4,8 @@ export type PathSelector<State> = (state: State) => string|Array<string>;
 
 interface PasswordConfig<State> extends TransformConfig {
   serviceName: string;
-  passwordPaths: string|Array<string>|PathSelector<State>;
+  accountName?: string;
+  passwordPaths?: string|Array<string>|PathSelector<State>;
   clearPasswords?: boolean;
   serialize?: boolean;
   logger?: Function;

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,0 +1,23 @@
+module.exports = (wallaby) => ({
+  name: 'redux-persist-transform-passwords',
+
+  files: [
+    'src/**/*.js'
+  ],
+
+  tests: [
+    'test/**/*.js'
+  ],
+
+  env: {
+    type: 'node',
+    runner: 'node',
+    params: { env: 'wallaby=true' }
+  },
+
+  testFramework: 'jest',
+
+  compilers: {
+    '**/*.js': wallaby.compilers.babel()
+  }
+});


### PR DESCRIPTION
This PR allows you to read or write an entire reducer into `keytar`, instead of providing individual paths via `passwordPaths`. A configuration like this:

``` js
createPasswordTransform({
  serviceName: 'Slack',
  accountName: 'tokens',
  whitelist: ['tokens']
});
```

Would, on persist, `JSON.stringify` all of the state under the `tokens` reducer and write that string into `keytar`. On hydrate, `tokens` would be read in from the keychain and applied to your state tree.