### PR TITLE
Add utility for testing keychain access

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,46 @@ You can find more usage examples by reading the tests.
 
 ## API
 
-* `createPasswordTransform(config)` - Creates a new transform instance
+### `createPasswordTransform(config)` - Creates a new transform instance.
 
-* `config (Object)` - Configuration parameters
+#### `config (Object)` - Configuration parameters
     * `serviceName (String)` - The top-level identifier for your app to store items in the keychain.
     * `accountName (String)` - (Optional) A sub-identifier for individual entries. If not provided, strings taken from `passwordPaths` will be used.
     * `passwordPaths (String|Array<String>|((state) => String|Array<String>)` - (Optional) Lodash getter path(s) to passwords in your state, or a function that, given your state, returns path(s). Leave empty to write the entire reducer.
     * `clearPasswords (Boolean)` - (Optional) Whether or not to clear the properties from `passwordPaths` before the state is persisted. Defaults to `true`.
     * `serialize (Boolean)` - (Optional) Whether or not to serialize password properties as JSON strings. Defaults to `false`.
     * `logger ((message, ...args) => void)` - (Optional) An optional logging method. Defaults to `noop`.
+
+### `accessKeychain(serviceName, accountName): Promise<boolean>` - Test for access to the keychain.
+
+Since we don't want to throw any errors during the state transform, we'll catch & log any exceptions in the keychain operation. To give consumers a way to check access beforehand (and to control the time at which the OS keychain prompt appears), we provide the `accessKeychain` method. You'll need to call this method _before_ your Redux store is rehydrated, since the rehydrate will attempt to read from the keychain:
+
+``` js
+import createPasswordTransform, {
+  accessKeychain
+} from 'redux-persist-transform-passwords';
+import createEncryptor from 'redux-persist-transform-encrypt';
+
+async createAndPersistStore() {
+  // Check if we can access the keychain first
+  // On some platforms this will pop an OS permissions dialog!
+  const canAccess = await accessKeychain();
+
+  // If we don't have access, fallback to encrypting the passwords
+  const passwordTransform = canAccess ? createPasswordTransform({
+    serviceName: 'MyApp',
+    accountName: 'Passwords',
+    whitelist: ['passwords']
+  }) : createEncryptor({
+    secretKey,
+    whitelist: ['passwords']
+  });
+
+  // Business as usual for redux-persist
+  persistStore(yourStore, {
+    asyncTransforms: true,
+    transforms: [passwordTransform]
+    ...
+  });
+}
+```

--- a/src/index.js
+++ b/src/index.js
@@ -88,15 +88,19 @@ export default function createPasswordTransform(config = {}) {
       }
       return inboundState;
     } else {
-      logger('TransformPasswords: Writing entire reducer');
+      try {
+        logger('TransformPasswords: Writing entire reducer');
 
-      await setPassword(
-        serviceName,
-        accountName,
-        coerceString(inboundState, serialize)
-      );
+        await setPassword(
+          serviceName,
+          accountName,
+          coerceString(inboundState, serialize)
+        );
 
-      return {};
+        return {};
+      } catch (err) {
+        logger('TransformPasswords: Unable to write reducer', err);
+      }
     }
   }
 
@@ -119,10 +123,14 @@ export default function createPasswordTransform(config = {}) {
 
       return outboundState;
     } else {
-      logger('TransformPasswords: Reading entire reducer');
+      try {
+        logger('TransformPasswords: Reading entire reducer');
 
-      const secret = await getPassword(serviceName, accountName);
-      return JSON.parse(secret);
+        const secret = await getPassword(serviceName, accountName);
+        return JSON.parse(secret);
+      } catch (err) {
+        logger('TransformPasswords: Unable to read reducer', err);
+      }
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,24 @@ import { set, unset } from 'lodash/fp';
 import { createTransform } from 'redux-persist';
 
 /**
+ * Utility function for consumers to check if they can access the keychain.
+ *
+ * @export
+ * @param {String} serviceName  The top-level identifier for your app to store items in the keychain.
+ * @param {String} accountName  A sub-identifier for individual entries.
+ * @returns {Promise<Boolean>}  True if the keychain can be accessed, false if it threw an error.
+ */
+export async function accessKeychain(serviceName, accountName) {
+  try {
+    const getPassword = require('keytar').getPassword;
+    await getPassword(serviceName, accountName);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+/**
  * Creates a new transform instance.
  *
  * @export

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ export default function createPasswordTransform(config = {}) {
       }
       return inboundState;
     } else {
-      logger('Writing entire reducer');
+      logger('TransformPasswords: Writing entire reducer');
 
       await setPassword(
         serviceName,
@@ -119,7 +119,7 @@ export default function createPasswordTransform(config = {}) {
 
       return outboundState;
     } else {
-      logger('Reading entire reducer');
+      logger('TransformPasswords: Reading entire reducer');
 
       const secret = await getPassword(serviceName, accountName);
       return JSON.parse(secret);
@@ -129,12 +129,12 @@ export default function createPasswordTransform(config = {}) {
   async function setPasswordForPath(inboundState, path) {
     const secret = get(inboundState, path);
     if (!secret) {
-      logger('Nothing found at path', path);
+      logger('TransformPasswords: Nothing found at path', path);
       return;
     }
 
     try {
-      logger(`Writing secret under ${path}`, secret);
+      logger(`TransformPasswords: Writing secret under ${path}`, secret);
 
       await setPassword(
         serviceName,
@@ -148,7 +148,7 @@ export default function createPasswordTransform(config = {}) {
         inboundState = unset(path, inboundState);
       }
     } catch (err) {
-      logger(`Unable to write ${path} to keytar`, err);
+      logger(`TransformPasswords: Unable to write ${path} to keytar`, err);
     }
 
     return inboundState;
@@ -157,7 +157,7 @@ export default function createPasswordTransform(config = {}) {
   async function getPasswordForPath(outboundState, path) {
     try {
       const secret = await getPassword(serviceName, accountName || path);
-      logger(`Read secret from ${path}`, secret);
+      logger(`TransformPasswords: Read secret from ${path}`, secret);
 
       // If we found a stored password, set it on the outbound state.
       // Use an immutable version of set to avoid modifying the original
@@ -167,7 +167,7 @@ export default function createPasswordTransform(config = {}) {
         outboundState = set(path, toSet, outboundState);
       }
     } catch (err) {
-      logger(`Unable to read ${path} from keytar`, err);
+      logger(`TransformPasswords: Unable to read ${path} from keytar`, err);
     }
 
     return outboundState;

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,9 @@ import { get } from 'lodash';
 import { getPassword, setPassword } from 'keytar';
 import deepFreeze from 'deep-freeze';
 
-import createPasswordTransform from '../src';
+import createPasswordTransform, {
+  accessKeychain
+} from '../src';
 
 jest.mock('keytar', () => ({
   getPassword: jest.fn(),
@@ -10,7 +12,6 @@ jest.mock('keytar', () => ({
 }));
 
 describe('createPasswordTransform', () => {
-
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -228,5 +229,22 @@ describe('createPasswordTransform', () => {
       expect(transformed).toEqual(result);
       expect(getPassword).toHaveBeenCalledWith('FedGovt', 'NSA');
     });
+  });
+});
+
+describe('accessKeychain', () => {
+  it('should return a boolean indicating whether or not we have keychain access', async () => {
+    getPassword.mockImplementationOnce(() => {
+      throw new Error();
+    });
+    getPassword.mockImplementationOnce(() => {
+      return 'hunter42';
+    });
+
+    let canAccess = await accessKeychain();
+    expect(canAccess).toEqual(false);
+
+    canAccess = await accessKeychain();
+    expect(canAccess).toEqual(true);
   });
 });

--- a/type-definitions/index.d.ts
+++ b/type-definitions/index.d.ts
@@ -12,3 +12,5 @@ interface PasswordConfig<State> extends TransformConfig {
 }
 
 export default function createPasswordTransform<State, Raw>(config?: PasswordConfig<State>): Transform<State, Raw>;
+
+export async function accessKeychain(serviceName: string, accountName: string): Promise<boolean>;


### PR DESCRIPTION
Since we don't want to throw any errors during the state transform, we catch & log any exceptions in the keychain operation. To give consumers a way to check access beforehand (and to control the time at which the OS keychain prompt appears), we provide the `accessKeychain` method.