### PR TITLE
fix: babel runtime is a prod dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "Charlie Hess",
   "license": "MIT",
   "dependencies": {
+    "babel-runtime": "^6.23.0",
     "keytar": "^4.0.3",
     "lodash": "^4.17.4"
   },


### PR DESCRIPTION
:wave: when installed with `--production` this library throws an error trying to import `babel-runtime` helpers.